### PR TITLE
Modulo operator on double type

### DIFF
--- a/src/mlpack/methods/linear_regression/linear_regression.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression.cpp
@@ -73,7 +73,9 @@ double LinearRegression::Train(const arma::mat& predictors,
   if (weights.n_elem > 0)
   {
     p = p * diagmat(sqrt(weights));
-    r = sqrt(weights) % responses;
+    //r = sqrt(weights) % responses;
+     r = sqrtl(weights) % responses;  // % operator works on integers only
+    
   }
 
   // Convert to this form:


### PR DESCRIPTION
In line number 76, the % operator is getting double data from the function sqrt().
This may be modified to sqrtl() for long int processing.